### PR TITLE
Separate nemo_cf cli

### DIFF
--- a/nemo_cf/cli.py
+++ b/nemo_cf/cli.py
@@ -1,8 +1,10 @@
 """Console script for nemo_cf."""
 import sys
+from pprint import pprint
 import click
 
 from .aux import download_and_extract_zip_file
+from .cf_attributes import mesh_mask_attrs
 
 
 @click.command()
@@ -15,7 +17,7 @@ from .aux import download_and_extract_zip_file
         "NEMO_GYRE_test_data_all_files.v2020.02.03.1.zip"
     ),
 )
-def main(target_dir, force, url):
+def download_data(target_dir, force, url):
     """Download NEMO example data."""
 
     download_and_extract_zip_file(url=url, target_dir=target_dir, force=force)
@@ -23,5 +25,15 @@ def main(target_dir, force, url):
     return 0
 
 
+@click.command()
+def print_info():
+    """Print info about NEMO cf."""
+
+    print("nemo_cf will apply the following attributes:\n")
+    pprint(mesh_mask_attrs)
+
+    return 0
+
+
 if __name__ == "__main__":
-    sys.exit(main())  # pragma: no cover
+    sys.exit(print_info())  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -4,49 +4,56 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file:
+with open("README.md") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.md') as history_file:
+with open("HISTORY.md") as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', ]
+requirements = [
+    "Click>=7.0",
+]
 
-setup_requirements = ['pytest-runner', ]
+setup_requirements = [
+    "pytest-runner",
+]
 
-test_requirements = ['pytest>=3', ]
+test_requirements = [
+    "pytest>=3",
+]
 
 setup(
     author="Willi Rath",
-    author_email='wrath@geomar.de',
-    python_requires='>=3.6',
+    author_email="wrath@geomar.de",
+    python_requires=">=3.6",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     description="Make NEMO output CF compliant",
     entry_points={
-        'console_scripts': [
-            'nemo_cf=nemo_cf.cli:main',
+        "console_scripts": [
+            "nemo_cf_info=nemo_cf.cli:print_info",
+            "nemo_cf_download_data=nemo_cf.cli:download_data",
         ],
     },
     install_requires=requirements,
     license="MIT license",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='nemo_cf',
-    name='nemo_cf',
-    packages=find_packages(include=['nemo_cf', 'nemo_cf.*']),
+    keywords="nemo_cf",
+    name="nemo_cf",
+    packages=find_packages(include=["nemo_cf", "nemo_cf.*"]),
     setup_requires=setup_requirements,
-    test_suite='tests',
+    test_suite="tests",
     tests_require=test_requirements,
-    url='https://github.com/willirath/nemo_cf',
-    version='0.1.0',
+    url="https://github.com/willirath/nemo_cf",
+    version="0.1.0",
     zip_safe=False,
 )

--- a/tests/test_nemo_cf_cli.py
+++ b/tests/test_nemo_cf_cli.py
@@ -7,9 +7,17 @@ from click.testing import CliRunner
 from nemo_cf import cli
 
 
-def test_command_line_interface():
+def test_cli_download_data_help():
     """Test the CLI."""
     runner = CliRunner()
-    help_result = runner.invoke(cli.main, ['--help'])
+    help_result = runner.invoke(cli.download_data, ["--help"])
     assert help_result.exit_code == 0
-    assert 'Download NEMO example data.' in help_result.output
+    assert "Download NEMO example data." in help_result.output
+
+
+def test_cli_print_info_help():
+    """Test the CLI."""
+    runner = CliRunner()
+    help_result = runner.invoke(cli.print_info, ["--help"])
+    assert help_result.exit_code == 0
+    assert "Print info about NEMO cf." in help_result.output


### PR DESCRIPTION
This separates the cli into

- `nemo_cf_info` which prints info on the applied attributes,
- `nemo_cf_download_data` which downloads test data from Zenodo.